### PR TITLE
fix: select dropdown renders behind dialog (z-index on positioner)

### DIFF
--- a/apps/desktop/src/renderer/components/ui/select.tsx
+++ b/apps/desktop/src/renderer/components/ui/select.tsx
@@ -54,7 +54,7 @@ export function SelectContent({
 }: ComponentPropsWithoutRef<typeof BaseSelect.Positioner>) {
   return (
     <BaseSelect.Portal>
-      <BaseSelect.Positioner sideOffset={sideOffset} alignItemWithTrigger={alignItemWithTrigger} {...props}>
+      <BaseSelect.Positioner sideOffset={sideOffset} alignItemWithTrigger={alignItemWithTrigger} className="select-positioner" {...props}>
         <BaseSelect.Popup className="glass-card select-popup">
           <BaseSelect.List className={cn('select-list', className)}>
             {children}

--- a/apps/desktop/src/renderer/global.css
+++ b/apps/desktop/src/renderer/global.css
@@ -433,8 +433,11 @@
     color: var(--color-foreground);
   }
 
-  .select-popup {
+  .select-positioner {
     z-index: 90;
+  }
+
+  .select-popup {
     min-width: var(--anchor-width);
     max-width: min(28rem, calc(100vw - 2rem));
     overflow: hidden;


### PR DESCRIPTION
## Summary

- Moves `z-index: 90` from `.select-popup` to a new `.select-positioner` class applied to `BaseSelect.Positioner`

## Root cause

`BaseSelect.Positioner` renders with `position: fixed`, which creates a new CSS stacking context. Without an explicit z-index on the positioner itself, it participates in the root stacking context at `z-index: auto` — painted *before* elements with a positive z-index like the dialog overlay (`z-index: 80`). The `z-index: 90` on the inner `.select-popup` was trapped inside the positioner's own stacking context and had no effect on dialog layering.

## Fix

Apply `z-index: 90` directly to the positioner element so it correctly stacks above the dialog backdrop (`z-index: 70`) and popup overlay (`z-index: 80`).

Closes #13 