### PR TITLE
fix: apply Maven default options to new pipeline steps

### DIFF
--- a/apps/desktop/src/renderer/components/PipelineDialog.tsx
+++ b/apps/desktop/src/renderer/components/PipelineDialog.tsx
@@ -49,16 +49,16 @@ interface PipelineDialogProps {
   mode: 'create' | 'edit';
 }
 
-function createEmptyStep(mavenGoals: string): StepFormData {
+function createEmptyStep(mavenGoals: string, mavenOptionKeys: MavenOptionKey[] = [], mavenExtraOptions: string[] = []): StepFormData {
   return {
     label: '',
     path: '',
     buildSystem: null,
     mavenModulePath: '',
     mavenGoals: mavenGoals ? mavenGoals.split(/\s+/).filter(Boolean) : ['clean', 'install'],
-    mavenOptionKeys: [],
+    mavenOptionKeys,
     mavenProfileStates: {},
-    mavenExtraOptions: [],
+    mavenExtraOptions,
     commandType: 'script',
     script: '',
     args: '',
@@ -527,6 +527,14 @@ export function PipelineDialog({
 }: PipelineDialogProps) {
   const { data: configData } = useQuery(configQuery);
   const defaultMavenGoals = configData?.config.maven.defaultGoals.join(' ') ?? 'clean install';
+  const defaultMavenOptionKeys = useMemo(
+    () => (configData?.config.maven.defaultOptionKeys ?? []) as MavenOptionKey[],
+    [configData],
+  );
+  const defaultMavenExtraOptions = useMemo(
+    () => configData?.config.maven.defaultExtraOptions ?? [],
+    [configData],
+  );
   const registeredJdkVersions = useMemo(
     () => Object.keys(configData?.config.jdkRegistry ?? {}),
     [configData],
@@ -535,7 +543,7 @@ export function PipelineDialog({
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [failFast, setFailFast] = useState(true);
-  const [steps, setSteps] = useState<StepFormData[]>([createEmptyStep(defaultMavenGoals)]);
+  const [steps, setSteps] = useState<StepFormData[]>([createEmptyStep(defaultMavenGoals, defaultMavenOptionKeys, defaultMavenExtraOptions)]);
 
   async function resolveStepPath(index: number, path: string, project?: Project) {
     const applyInspection = (current: StepFormData, resolvedProject: Project | null, error?: string): StepFormData => {
@@ -640,7 +648,7 @@ export function PipelineDialog({
     const nextSteps =
       initialData?.steps.length
         ? initialData.steps.map((step) => fromApiStep(step, defaultMavenGoals))
-        : [createEmptyStep(defaultMavenGoals)];
+        : [createEmptyStep(defaultMavenGoals, defaultMavenOptionKeys, defaultMavenExtraOptions)];
 
     setName(initialData?.name ?? '');
     setDescription(initialData?.description ?? '');
@@ -659,10 +667,10 @@ export function PipelineDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, initialData, defaultMavenGoals, registeredJdkVersions]);
+  }, [open, initialData, defaultMavenGoals, defaultMavenOptionKeys, defaultMavenExtraOptions, registeredJdkVersions]);
 
   function addStep() {
-    setSteps((current) => [...current, createEmptyStep(defaultMavenGoals)]);
+    setSteps((current) => [...current, createEmptyStep(defaultMavenGoals, defaultMavenOptionKeys, defaultMavenExtraOptions)]);
   }
 
   function removeStep(index: number) {

--- a/apps/desktop/src/renderer/routes/settings/index.tsx
+++ b/apps/desktop/src/renderer/routes/settings/index.tsx
@@ -463,7 +463,7 @@ function SettingsView() {
                 placeholder="e.g. -T4"
               />
               <p className="text-[11px] leading-relaxed text-muted-foreground/72">
-                Optional extra Maven options appended to new runs by default.
+                Optional extra Maven options appended to new runs by default. Type an option and press <kbd className="rounded border border-border px-1 font-mono text-[10px]">Enter</kbd> to add it.
               </p>
             </div>
           </ConfigCard>


### PR DESCRIPTION
## Summary
- `createEmptyStep` in `PipelineDialog.tsx` now receives and applies `defaultOptionKeys` and `defaultExtraOptions` from settings, fixing pipeline creation ignoring these defaults
- `addStep` and the dialog reset `useEffect` also pass the defaults, so every new step picks them up
- Added a press-Enter hint below the extra options TagInput in settings to clarify the required interaction

Closes #11