### PR TITLE
fix: standardize dropdown chevron and Escape behavior

### DIFF
--- a/apps/desktop/src/renderer/components/PipelineDialog.tsx
+++ b/apps/desktop/src/renderer/components/PipelineDialog.tsx
@@ -8,7 +8,7 @@ import { ComboboxField } from '@/components/ui/combobox-field';
 import { Tooltip } from '@/components/ui/tooltip';
 import { getNodeScriptChoices, getNodeScriptComboboxOptions, type NodeScriptChoice } from '@/lib/node-script-options';
 import { cn } from '@/lib/utils';
-import { Plus, Trash2, ArrowUp, ArrowDown, FolderOpen, Loader2, Check } from 'lucide-react';
+import { Plus, Trash2, ArrowUp, ArrowDown, FolderOpen, Loader2, Check, ChevronDown } from 'lucide-react';
 import type { PipelineStep } from '@gfos-build/contracts';
 import type { ExecutionMode, MavenMetadata, MavenOptionKey, MavenProfileState, NodeCommandType, PackageManager, Project } from '@gfos-build/contracts';
 import { pickDirectory } from '@/api/bridge';
@@ -212,7 +212,14 @@ function ProjectPathPicker({
             }}
             onKeyDown={handleKeyDown}
             placeholder={open ? 'Search projects or type an absolute path...' : 'Select a project...'}
-            className="field-input h-11 w-full rounded-2xl border px-4 [background:var(--field-bg)] [border-color:var(--field-border)] focus:outline-none focus:border-ring focus:[box-shadow:0_0_0_1px_var(--color-ring)]"
+            className="field-input h-11 w-full rounded-2xl border pl-4 pr-10 [background:var(--field-bg)] [border-color:var(--field-border)] focus:outline-none focus:border-ring focus:[box-shadow:0_0_0_1px_var(--color-ring)]"
+          />
+          <ChevronDown
+            size={15}
+            className={cn(
+              'pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-transform',
+              open && 'rotate-180',
+            )}
           />
 
           {open && (

--- a/apps/desktop/src/renderer/components/ui/combobox-field.tsx
+++ b/apps/desktop/src/renderer/components/ui/combobox-field.tsx
@@ -126,6 +126,11 @@ export function ComboboxField({
 
           if (event.key === 'Escape') {
             event.preventDefault();
+            if (open) {
+              // Prevent the parent dialog from seeing this Escape so it doesn't
+              // trigger the discard-confirmation while just closing the dropdown.
+              event.nativeEvent.stopImmediatePropagation();
+            }
             setOpen(false);
             setQuery('');
             inputRef.current?.blur();


### PR DESCRIPTION
## Summary

- Add missing `ChevronDown` indicator to `ProjectPathPicker` (the Project Path dropdown had no chevron, unlike the Submodule picker and JAVA_HOME override)
- Stop Escape propagation in `ComboboxField` when the dropdown is open, matching the existing behavior in `ProjectPathPicker` — prevents the parent dialog's discard-confirmation from triggering when the user just wants to close the dropdown

## Test plan

- [ ] Open the Create Pipeline dialog and verify all three dropdowns (Project Path, Submodule, JAVA_HOME override) show a chevron indicator
- [ ] Verify the chevron rotates 180° when the Project Path dropdown is open
- [ ] Press Escape while the Submodule or Script picker dropdown is open — confirm it only closes the dropdown and does not trigger the discard-confirmation dialog

Closes #15