### PR TITLE
feat: add Fail Fast tooltip, cursor pointer, and tooltip animations

### DIFF
--- a/apps/desktop/src/renderer/components/PipelineDialog.tsx
+++ b/apps/desktop/src/renderer/components/PipelineDialog.tsx
@@ -775,17 +775,19 @@ export function PipelineDialog({
               value={description}
               onChange={(e) => { setIsDirty(true); setDescription(e.target.value); }}
             />
-            <button
-              type="button"
-              aria-pressed={failFast}
-              onClick={() => { setIsDirty(true); setFailFast((current) => !current); }}
-              className={cn('toggle-pill', failFast && 'is-active')}
-            >
-              <span className="toggle-pill-indicator">
-                {failFast ? <Check size={11} /> : null}
-              </span>
-              Fail fast
-            </button>
+            <Tooltip content="Stop the pipeline execution immediately if a step fails." side="top">
+              <button
+                type="button"
+                aria-pressed={failFast}
+                onClick={() => { setIsDirty(true); setFailFast((current) => !current); }}
+                className={cn('toggle-pill', failFast && 'is-active')}
+              >
+                <span className="toggle-pill-indicator">
+                  {failFast ? <Check size={11} /> : null}
+                </span>
+                Fail fast
+              </button>
+            </Tooltip>
           </div>
 
           <div className="mt-5 min-h-0 flex-1 overflow-y-auto overflow-x-visible px-1 py-1 -mx-1 -my-1 pr-3">

--- a/apps/desktop/src/renderer/global.css
+++ b/apps/desktop/src/renderer/global.css
@@ -591,6 +591,7 @@
     font-weight: 500;
     color: var(--color-muted-foreground);
     box-shadow: inset 0 1px 0 var(--field-highlight);
+    cursor: pointer;
   }
 
   .toggle-pill:hover {
@@ -700,6 +701,25 @@
     color: var(--color-popover-foreground);
     box-shadow: 0 10px 30px rgb(0 0 0 / 0.16);
     backdrop-filter: blur(14px);
+    transform-origin: var(--transform-origin);
+  }
+
+  .tooltip-popup[data-open] {
+    animation: tooltip-in 120ms ease forwards;
+  }
+
+  .tooltip-popup[data-closed] {
+    animation: tooltip-out 120ms ease forwards;
+  }
+
+  @keyframes tooltip-in {
+    from { opacity: 0; transform: scale(0.94); }
+    to   { opacity: 1; transform: scale(1); }
+  }
+
+  @keyframes tooltip-out {
+    from { opacity: 1; transform: scale(1); }
+    to   { opacity: 0; transform: scale(0.94); }
   }
 
   .tooltip-kbd {


### PR DESCRIPTION
Closes #16

## Summary
- Added a tooltip to the **Fail Fast** toggle in the pipeline dialog explaining: *"Stop the pipeline execution immediately if a step fails."*
- Added `cursor: pointer` to `.toggle-pill` so it feels interactive on hover
- Added smooth fade + scale enter/exit animations to all tooltips via `@keyframes`

## Test plan
- [ ] Open the Create/Edit pipeline dialog and hover over the **Fail Fast** toggle — tooltip should appear with a fade-in animation
- [ ] Move cursor away — tooltip should fade out
- [ ] Verify the toggle cursor is a pointer on hover