### PR TITLE
fix: detect java version from sub-modules in multi-module Maven projects

### DIFF
--- a/packages/application/src/maven-project.ts
+++ b/packages/application/src/maven-project.ts
@@ -83,13 +83,15 @@ export async function inspectMavenProject(fs: FileSystem, projectPath: string): 
     }
   }
 
+  const dedupedModules = dedupeModules(modules);
+
   return {
     pomPath,
     artifactId: rootArtifactId,
     packaging: rootPackaging,
     isAggregator,
-    javaVersion: rootJavaVersion,
-    modules: dedupeModules(modules),
+    javaVersion: highestJavaVersion([rootJavaVersion, ...dedupedModules.map((m) => m.javaVersion)]),
+    modules: dedupedModules,
     profiles: dedupeProfiles(profiles),
     hasMvnConfig,
     mvnConfigContent,
@@ -112,6 +114,16 @@ function dedupeProfiles(profiles: MavenProfileMetadata[]): MavenProfileMetadata[
   return [...byKey.values()].sort(
     (a, b) => a.id.localeCompare(b.id) || a.sourceModulePath.localeCompare(b.sourceModulePath),
   );
+}
+
+function highestJavaVersion(versions: (string | undefined)[]): string | undefined {
+  const parsed = versions
+    .filter((v): v is string => v !== undefined)
+    .map((v) => ({ raw: v, numeric: parseInt(v, 10) }))
+    .filter((v) => !isNaN(v.numeric));
+
+  if (parsed.length === 0) return undefined;
+  return parsed.reduce((a, b) => (b.numeric > a.numeric ? b : a)).raw;
 }
 
 function toPortablePath(value: string): string {

--- a/tests/core/repository-scanner.test.ts
+++ b/tests/core/repository-scanner.test.ts
@@ -206,6 +206,70 @@ describe('RepositoryScanner', () => {
     }
   });
 
+  it('falls back to sub-module java version when root pom.xml has none', async () => {
+    const fs = new InMemoryFileSystem();
+    const rootPath = path.resolve('/workspaces/gfoshg');
+
+    fs.addDirectory(rootPath, [dirEntry('standard', true)]);
+    fs.addDirectory(path.join(rootPath, 'standard'), [dirEntry('maven', true)]);
+    fs.addDirectory(path.join(rootPath, 'standard', 'maven'), []);
+    fs.addFile(
+      path.join(rootPath, 'pom.xml'),
+      '<project><artifactId>gfoshg-2025</artifactId><packaging>pom</packaging><modules><module>standard/maven</module></modules></project>',
+    );
+    fs.addFile(
+      path.join(rootPath, 'standard', 'maven', 'pom.xml'),
+      '<project><artifactId>standard</artifactId><properties><maven.compiler.source>21</maven.compiler.source></properties></project>',
+    );
+
+    const scanner = new RepositoryScanner(fs);
+    const events = await collectEvents(scanner, {
+      roots: { test: rootPath },
+      includeHidden: false,
+      exclude: [],
+    });
+
+    const found = events.find((e) => e.type === 'repo:found');
+    expect(found).toBeDefined();
+    if (found?.type === 'repo:found') {
+      expect(found.project.maven?.javaVersion).toBe('21');
+    }
+  });
+
+  it('picks highest java version when sub-modules differ', async () => {
+    const fs = new InMemoryFileSystem();
+    const rootPath = path.resolve('/workspaces/mixed');
+
+    fs.addDirectory(rootPath, [dirEntry('moduleA', true), dirEntry('moduleB', true)]);
+    fs.addDirectory(path.join(rootPath, 'moduleA'), []);
+    fs.addDirectory(path.join(rootPath, 'moduleB'), []);
+    fs.addFile(
+      path.join(rootPath, 'pom.xml'),
+      '<project><artifactId>mixed</artifactId><packaging>pom</packaging><modules><module>moduleA</module><module>moduleB</module></modules></project>',
+    );
+    fs.addFile(
+      path.join(rootPath, 'moduleA', 'pom.xml'),
+      '<project><artifactId>moduleA</artifactId><properties><maven.compiler.source>17</maven.compiler.source></properties></project>',
+    );
+    fs.addFile(
+      path.join(rootPath, 'moduleB', 'pom.xml'),
+      '<project><artifactId>moduleB</artifactId><properties><maven.compiler.source>21</maven.compiler.source></properties></project>',
+    );
+
+    const scanner = new RepositoryScanner(fs);
+    const events = await collectEvents(scanner, {
+      roots: { test: rootPath },
+      includeHidden: false,
+      exclude: [],
+    });
+
+    const found = events.find((e) => e.type === 'repo:found');
+    expect(found).toBeDefined();
+    if (found?.type === 'repo:found') {
+      expect(found.project.maven?.javaVersion).toBe('21');
+    }
+  });
+
   it('scans multiple roots', async () => {
     const fs = new InMemoryFileSystem();
     const root1 = path.resolve('/workspaces/root1');


### PR DESCRIPTION
## Summary

- Fixes Java version detection for multi-module Maven projects where the version is only defined in a sub-module, not the root `pom.xml`
- Instead of only reading the root POM, the detected version is now the **highest** Java version found across the root and all sub-modules — ensuring the suggested JDK is compatible with every module in the reactor build
- Adds two new tests covering the reported scenario and the mixed-version case

Fixes #14

## Test plan

- [ ] Verify a multi-module project with Java version only in a sub-module shows the correct version in the pipeline view and ad hoc builds
- [ ] Verify a project with different Java versions across sub-modules shows the highest version
- [ ] Verify projects with Java version in the root POM are unaffected