### PR TITLE
fix(scan): improve project scan cache behavior

### DIFF
--- a/apps/desktop/src/renderer/api/queries.ts
+++ b/apps/desktop/src/renderer/api/queries.ts
@@ -61,6 +61,7 @@ export const scanQuery = queryOptions({
   queryFn: (): Promise<ScanResponse> => getDesktopApi().getScan(),
   staleTime: 60_000,
   gcTime: 300_000,
+  placeholderData: (previous) => previous,
 });
 
 export function useRunPipeline() {

--- a/apps/desktop/src/renderer/api/run-events.ts
+++ b/apps/desktop/src/renderer/api/run-events.ts
@@ -118,3 +118,29 @@ export async function waitForJobCompletion(jobId: string): Promise<void> {
     });
   });
 }
+
+export async function waitForScanCompletion(jobId: string): Promise<Extract<ScanEvent, { type: 'scan:done' }>> {
+  const entry = getCacheEntry(jobId);
+  const cachedDoneEvent = [...entry.events]
+    .reverse()
+    .find((event): event is Extract<ScanEvent, { type: 'scan:done' }> => event.type === 'scan:done');
+
+  if (cachedDoneEvent) {
+    return cachedDoneEvent;
+  }
+
+  return await new Promise<Extract<ScanEvent, { type: 'scan:done' }>>((resolve, reject) => {
+    const unsubscribe = getDesktopApi().onRunEvent(jobId, (envelope: RunEventEnvelope) => {
+      if (envelope.type === 'event' && envelope.event?.type === 'scan:done') {
+        unsubscribe();
+        resolve(envelope.event);
+        return;
+      }
+
+      if (envelope.type === 'error') {
+        unsubscribe();
+        reject(new Error(envelope.message ?? 'Job failed.'));
+      }
+    });
+  });
+}

--- a/apps/desktop/src/renderer/routes/projects/index.tsx
+++ b/apps/desktop/src/renderer/routes/projects/index.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { scanQuery, configQuery, useRefreshScan, useQuickRun } from '@/api/queries';
-import { waitForJobCompletion } from '@/api/run-events';
-import { useState, useMemo, useEffect, useDeferredValue } from 'react';
+import { waitForJobCompletion, waitForScanCompletion } from '@/api/run-events';
+import { useState, useMemo, useEffect, useDeferredValue, useRef, startTransition } from 'react';
 import {
   FolderSearch,
   RefreshCw,
@@ -45,6 +45,7 @@ import type {
   MavenSubmoduleBuildStrategy,
   NodeCommandType,
   Project,
+  ScanResponse,
 } from '@gfos-build/contracts';
 
 export const Route = createFileRoute('/projects/')({
@@ -53,6 +54,7 @@ export const Route = createFileRoute('/projects/')({
 
 type SysFilter = 'all' | 'maven' | 'node';
 type SortBy = 'name-asc' | 'name-desc' | 'path-asc' | 'sys';
+const AUTO_REFRESH_SCAN_MAX_AGE_MS = 3 * 60 * 1000;
 
 interface GroupData {
   key: string;
@@ -574,6 +576,8 @@ function ProjectsView() {
   const [buildTarget, setBuildTarget] = useState<Project | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
+  const lastAutoRefreshScanAtRef = useRef<string | null>(null);
+  const isRefreshInFlightRef = useRef(false);
 
   const projects = useMemo(() => scanData?.projects ?? [], [scanData]);
   const roots = useMemo(() => configData?.config.roots ?? {}, [configData]);
@@ -668,20 +672,65 @@ function ProjectsView() {
     setExpanded(new Set());
   }
 
-  async function handleRefresh() {
-    setIsRefreshing(true);
-    setRefreshError(null);
+  async function handleRefresh(options?: { showError?: boolean; background?: boolean }) {
+    if (isRefreshInFlightRef.current) {
+      return;
+    }
+    isRefreshInFlightRef.current = true;
+    if (!(options?.background ?? false)) {
+      setIsRefreshing(true);
+    }
+    if (options?.showError ?? true) {
+      setRefreshError(null);
+    }
     try {
       const { jobId } = await refreshScan.mutateAsync();
+      const scanResult = await waitForScanCompletion(jobId);
       await waitForJobCompletion(jobId);
-      await queryClient.invalidateQueries({ queryKey: ['scan'] });
+      startTransition(() => {
+        queryClient.setQueryData<ScanResponse>(['scan'], (previous) =>
+          mergeScanResponse(previous, {
+            projects: scanResult.projects,
+            durationMs: scanResult.durationMs,
+            fromCache: false,
+            scannedAt: scanResult.scannedAt,
+          }),
+        );
+      });
       await queryClient.invalidateQueries({ queryKey: ['git-info'] });
     } catch (error) {
-      setRefreshError(error instanceof Error ? error.message : 'Refresh scan failed.');
+      if (options?.showError ?? true) {
+        setRefreshError(error instanceof Error ? error.message : 'Refresh scan failed.');
+      }
     } finally {
-      setIsRefreshing(false);
+      isRefreshInFlightRef.current = false;
+      if (!(options?.background ?? false)) {
+        setIsRefreshing(false);
+      }
     }
   }
+
+  useEffect(() => {
+    if (!scanData?.fromCache || isRefreshInFlightRef.current) {
+      return;
+    }
+
+    const scannedAtMs = Date.parse(scanData.scannedAt);
+    if (Number.isNaN(scannedAtMs)) {
+      return;
+    }
+
+    if (Date.now() - scannedAtMs < AUTO_REFRESH_SCAN_MAX_AGE_MS) {
+      return;
+    }
+
+    if (lastAutoRefreshScanAtRef.current === scanData.scannedAt) {
+      return;
+    }
+
+    lastAutoRefreshScanAtRef.current = scanData.scannedAt;
+    void handleRefresh({ showError: false, background: true });
+  }, [scanData?.fromCache, scanData?.scannedAt]);
 
   async function handleBuildRun(payload: {
     buildSystem: 'maven' | 'node';
@@ -948,6 +997,132 @@ function ProjectsView() {
         isRunning={quickRun.isPending}
       />
     </div>
+  );
+}
+
+function mergeScanResponse(previous: ScanResponse | undefined, next: ScanResponse): ScanResponse {
+  if (!previous) {
+    return next;
+  }
+
+  const previousProjectsByPath = new Map(previous.projects.map((project) => [project.path, project]));
+  let didChange = previous.projects.length !== next.projects.length;
+
+  const mergedProjects = next.projects.map((project, index) => {
+    const previousProject = previousProjectsByPath.get(project.path);
+    if (previousProject && areProjectsEquivalent(previousProject, project)) {
+      const previousProjectAtIndex = previous.projects[index];
+      if (previousProjectAtIndex !== previousProject) {
+        didChange = true;
+      }
+      return previousProject;
+    }
+    didChange = true;
+    return project;
+  });
+
+  const projects =
+    !didChange && mergedProjects.every((project, index) => project === previous.projects[index])
+      ? previous.projects
+      : mergedProjects;
+
+  if (
+    projects === previous.projects &&
+    previous.durationMs === next.durationMs &&
+    previous.fromCache === next.fromCache &&
+    previous.scannedAt === next.scannedAt
+  ) {
+    return previous;
+  }
+
+  return {
+    ...next,
+    projects,
+  };
+}
+
+function areProjectsEquivalent(previous: Project, next: Project): boolean {
+  return (
+    previous.name === next.name &&
+    previous.path === next.path &&
+    previous.depth === next.depth &&
+    previous.rootName === next.rootName &&
+    previous.buildSystem === next.buildSystem &&
+    areMavenMetadataEquivalent(previous.maven, next.maven) &&
+    areNodeMetadataEquivalent(previous.node, next.node)
+  );
+}
+
+function areMavenMetadataEquivalent(previous: Project['maven'], next: Project['maven']): boolean {
+  if (previous === next) return true;
+  if (!previous || !next) return previous === next;
+
+  return (
+    previous.pomPath === next.pomPath &&
+    previous.artifactId === next.artifactId &&
+    previous.packaging === next.packaging &&
+    previous.isAggregator === next.isAggregator &&
+    previous.javaVersion === next.javaVersion &&
+    previous.hasMvnConfig === next.hasMvnConfig &&
+    previous.mvnConfigContent === next.mvnConfigContent &&
+    areMavenModulesEquivalent(previous.modules, next.modules) &&
+    areMavenProfilesEquivalent(previous.profiles, next.profiles)
+  );
+}
+
+function areMavenModulesEquivalent(previous: NonNullable<Project['maven']>['modules'], next: NonNullable<Project['maven']>['modules']): boolean {
+  return (
+    previous.length === next.length &&
+    previous.every((moduleEntry, index) => {
+      const nextEntry = next[index];
+      return (
+        nextEntry !== undefined &&
+        moduleEntry.id === nextEntry.id &&
+        moduleEntry.name === nextEntry.name &&
+        moduleEntry.relativePath === nextEntry.relativePath &&
+        moduleEntry.fullPath === nextEntry.fullPath &&
+        moduleEntry.packaging === nextEntry.packaging &&
+        moduleEntry.javaVersion === nextEntry.javaVersion
+      );
+    })
+  );
+}
+
+function areMavenProfilesEquivalent(previous: NonNullable<Project['maven']>['profiles'], next: NonNullable<Project['maven']>['profiles']): boolean {
+  return (
+    previous.length === next.length &&
+    previous.every((profile, index) => {
+      const nextProfile = next[index];
+      return (
+        nextProfile !== undefined &&
+        profile.id === nextProfile.id &&
+        profile.activeByDefault === nextProfile.activeByDefault &&
+        profile.sourcePomPath === nextProfile.sourcePomPath &&
+        profile.sourceModulePath === nextProfile.sourceModulePath
+      );
+    })
+  );
+}
+
+function areNodeMetadataEquivalent(previous: Project['node'], next: Project['node']): boolean {
+  if (previous === next) return true;
+  if (!previous || !next) return previous === next;
+
+  const previousScripts = Object.entries(previous.scripts).sort(([left], [right]) => left.localeCompare(right));
+  const nextScripts = Object.entries(next.scripts).sort(([left], [right]) => left.localeCompare(right));
+
+  return (
+    previous.packageJsonPath === next.packageJsonPath &&
+    previous.name === next.name &&
+    previous.version === next.version &&
+    previous.packageManager === next.packageManager &&
+    previous.isAngular === next.isAngular &&
+    previous.angularVersion === next.angularVersion &&
+    previousScripts.length === nextScripts.length &&
+    previousScripts.every(([key, value], index) => {
+      const nextEntry = nextScripts[index];
+      return nextEntry !== undefined && key === nextEntry[0] && value === nextEntry[1];
+    })
   );
 }
 

--- a/packages/application/src/repository-scanner.ts
+++ b/packages/application/src/repository-scanner.ts
@@ -6,6 +6,10 @@ import type { FileSystem } from './file-system.js';
 
 export type { ScanOptions } from '@gfos-build/domain';
 
+export interface ScanInstrumentation {
+  trackPath?: (path: string) => void;
+}
+
 const HARD_SKIPPED_DIRECTORIES = new Set([
   'node_modules',
   '.git',
@@ -21,19 +25,22 @@ const HARD_SKIPPED_DIRECTORIES = new Set([
 export class RepositoryScanner {
   constructor(private readonly fs: FileSystem) {}
 
-  async *scan(options: ScanOptions): AsyncGenerator<ScanEvent> {
+  async *scan(options: ScanOptions, instrumentation?: ScanInstrumentation): AsyncGenerator<ScanEvent> {
     const startTime = Date.now();
     const discovered: Project[] = [];
     const seen = new Set<string>();
     const claimedMavenModuleDirs = new Set<string>();
+    const trackPath = instrumentation?.trackPath;
 
     for (const [rootName, rootPath] of Object.entries(options.roots)) {
       if (!(await this.fs.exists(rootPath))) continue;
+      trackPath?.(rootPath);
 
       const queue: Array<{ dir: string; depth: number }> = [{ dir: rootPath, depth: 0 }];
 
       while (queue.length > 0) {
         const { dir, depth } = queue.shift()!;
+        trackPath?.(dir);
         if (seen.has(dir)) continue;
         if (claimedMavenModuleDirs.has(path.normalize(dir))) {
           seen.add(dir);
@@ -42,10 +49,14 @@ export class RepositoryScanner {
 
         const pomPath = path.join(dir, 'pom.xml');
         if (await this.fs.exists(pomPath)) {
+          trackPath?.(pomPath);
           seen.add(dir);
           const maven = await inspectMavenProject(this.fs, dir);
           if (!maven) {
             continue;
+          }
+          for (const trackedPath of getMavenValidationPaths(maven)) {
+            trackPath?.(trackedPath);
           }
           for (const moduleEntry of maven.modules) {
             claimedMavenModuleDirs.add(path.normalize(moduleEntry.fullPath));
@@ -66,8 +77,12 @@ export class RepositoryScanner {
         // Check for Angular workspace (angular.json takes priority over package.json)
         const angularJsonPath = path.join(dir, 'angular.json');
         if (await this.fs.exists(angularJsonPath)) {
+          trackPath?.(angularJsonPath);
           seen.add(dir);
           const node = await inspectNodeProject(this.fs, dir, true);
+          for (const trackedPath of await getNodeValidationPaths(this.fs, dir, node?.packageJsonPath, true)) {
+            trackPath?.(trackedPath);
+          }
           const project: Project = {
             name: path.basename(dir),
             path: dir,
@@ -84,8 +99,12 @@ export class RepositoryScanner {
         // Check for a plain Node project (package.json without pom.xml or angular.json)
         const packageJsonPath = path.join(dir, 'package.json');
         if (await this.fs.exists(packageJsonPath)) {
+          trackPath?.(packageJsonPath);
           seen.add(dir);
           const node = await inspectNodeProject(this.fs, dir, false);
+          for (const trackedPath of await getNodeValidationPaths(this.fs, dir, node?.packageJsonPath, false)) {
+            trackPath?.(trackedPath);
+          }
           const project: Project = {
             name: path.basename(dir),
             path: dir,
@@ -121,6 +140,45 @@ export class RepositoryScanner {
       projects: [...discovered].sort((a, b) => a.path.localeCompare(b.path)),
       durationMs: Date.now() - startTime,
       fromCache: false,
+      scannedAt: new Date().toISOString(),
     };
   }
+}
+
+function getMavenValidationPaths(project: NonNullable<Project['maven']>): string[] {
+  const tracked = new Set<string>([project.pomPath]);
+  for (const moduleEntry of project.modules) {
+    tracked.add(path.join(moduleEntry.fullPath, 'pom.xml'));
+  }
+  for (const profile of project.profiles) {
+    tracked.add(profile.sourcePomPath);
+  }
+  if (project.hasMvnConfig) {
+    tracked.add(path.join(path.dirname(project.pomPath), '.mvn', 'maven.config'));
+  }
+  return [...tracked];
+}
+
+async function getNodeValidationPaths(
+  fs: FileSystem,
+  dir: string,
+  packageJsonPath: string | undefined,
+  includeAngularJson: boolean,
+): Promise<string[]> {
+  const tracked = new Set<string>();
+  if (packageJsonPath) {
+    tracked.add(packageJsonPath);
+  }
+  if (includeAngularJson) {
+    tracked.add(path.join(dir, 'angular.json'));
+  }
+
+  for (const filename of ['bun.lock', 'bun.lockb', 'pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json']) {
+    const candidatePath = path.join(dir, filename);
+    if (await fs.exists(candidatePath)) {
+      tracked.add(candidatePath);
+    }
+  }
+
+  return [...tracked];
 }

--- a/packages/application/src/scanner.ts
+++ b/packages/application/src/scanner.ts
@@ -3,8 +3,8 @@ import type { ScanEvent } from '@gfos-build/domain';
 import type { RepositoryScanner, ScanOptions } from './repository-scanner.js';
 
 export interface ScanCacheStore {
-  get(key: string, ttlMs: number): import('@gfos-build/domain').Project[] | null;
-  set(key: string, projects: import('@gfos-build/domain').Project[]): void;
+  get(key: string, ttlMs: number): { projects: import('@gfos-build/domain').Project[]; scannedAt: string } | null;
+  set(key: string, projects: import('@gfos-build/domain').Project[], validationPaths: string[], scannedAt: string): void;
 }
 
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -21,22 +21,27 @@ export class CachedScanner {
     noCache = false,
   ): AsyncGenerator<ScanEvent> {
     const cacheKey = buildCacheKey(options);
+    const validationPaths = new Set<string>();
 
     if (!noCache) {
       const cached = this.cache.get(cacheKey, ttlMs);
       if (cached) {
-        for (const project of cached) {
+        for (const project of cached.projects) {
           yield { type: 'repo:found', project };
         }
-        yield { type: 'scan:done', projects: cached, durationMs: 0, fromCache: true };
+        yield { type: 'scan:done', projects: cached.projects, durationMs: 0, fromCache: true, scannedAt: cached.scannedAt };
         return;
       }
     }
 
-    for await (const event of this.scanner.scan(options)) {
+    for await (const event of this.scanner.scan(options, {
+      trackPath: (trackedPath) => {
+        validationPaths.add(trackedPath);
+      },
+    })) {
       yield event;
       if (event.type === 'scan:done') {
-        this.cache.set(cacheKey, event.projects);
+        this.cache.set(cacheKey, event.projects, [...validationPaths].sort(), event.scannedAt);
       }
     }
   }

--- a/packages/contracts/api.ts
+++ b/packages/contracts/api.ts
@@ -126,6 +126,7 @@ export interface ScanResponse {
   projects: Project[];
   durationMs: number;
   fromCache: boolean;
+  scannedAt: string;
 }
 
 export interface ProjectInspectionResponse {

--- a/packages/contracts/types.ts
+++ b/packages/contracts/types.ts
@@ -128,7 +128,7 @@ export type ProcessEvent =
 
 export type ScanEvent =
   | { type: 'repo:found'; project: Project }
-  | { type: 'scan:done'; projects: Project[]; durationMs: number; fromCache: boolean };
+  | { type: 'scan:done'; projects: Project[]; durationMs: number; fromCache: boolean; scannedAt: string };
 
 export interface ScanOptions {
   roots: Record<string, string>;

--- a/packages/platform-node/src/runtime.ts
+++ b/packages/platform-node/src/runtime.ts
@@ -58,7 +58,7 @@ import {
   type PipelineConfig,
 } from './schema.js';
 
-const DEFAULT_SCAN_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_SCAN_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_SCAN_JOB_TTL_MS = 5 * 60 * 1000;
 const MAX_JOB_HISTORY = 20_000;
 
@@ -238,13 +238,14 @@ export class AppRuntime {
 
   async getScan(noCache = false): Promise<ScanResponse> {
     const config = this.getSettings();
-    let result: ScanResponse = { projects: [], durationMs: 0, fromCache: false };
+    let result: ScanResponse = { projects: [], durationMs: 0, fromCache: false, scannedAt: new Date(0).toISOString() };
     for await (const event of this.scanner.scan(toScanOptions(config), DEFAULT_SCAN_CACHE_TTL_MS, noCache)) {
       if (event.type === 'scan:done') {
         result = {
           projects: event.projects,
           durationMs: event.durationMs,
           fromCache: event.fromCache,
+          scannedAt: event.scannedAt,
         };
       }
     }

--- a/packages/platform-node/src/scan-cache.ts
+++ b/packages/platform-node/src/scan-cache.ts
@@ -2,24 +2,30 @@ import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync }
 import path from 'node:path';
 import type { Project } from '@gfos-build/domain';
 
-const SCAN_CACHE_VERSION = 1;
+const SCAN_CACHE_VERSION = 2;
+
+interface ValidationEntry {
+  path: string;
+  mtimeMs: number | null;
+}
 
 interface ScanCacheRecord {
   version: number;
   createdAt: string;
   projects: Project[];
+  validationEntries: ValidationEntry[];
 }
 
 export interface ScanCacheStore {
-  get(key: string, ttlMs: number): Project[] | null;
-  set(key: string, projects: Project[]): void;
+  get(key: string, ttlMs: number): { projects: Project[]; scannedAt: string } | null;
+  set(key: string, projects: Project[], validationPaths: string[], scannedAt: string): void;
   clear(): void;
 }
 
 export class FileScanCacheStore implements ScanCacheStore {
   constructor(private readonly cacheDir: string) {}
 
-  get(key: string, ttlMs: number): Project[] | null {
+  get(key: string, ttlMs: number): { projects: Project[]; scannedAt: string } | null {
     const filePath = this.getEntryPath(key);
     try {
       const stats = statSync(filePath);
@@ -30,22 +36,28 @@ export class FileScanCacheStore implements ScanCacheStore {
 
       const raw = readFileSync(filePath, 'utf8');
       const parsed = JSON.parse(raw) as ScanCacheRecord;
-      if (parsed.version !== SCAN_CACHE_VERSION || !Array.isArray(parsed.projects)) {
+      if (
+        parsed.version !== SCAN_CACHE_VERSION ||
+        !Array.isArray(parsed.projects) ||
+        !Array.isArray(parsed.validationEntries) ||
+        !this.isValidationSnapshotCurrent(parsed.validationEntries)
+      ) {
         rmSync(filePath, { force: true });
         return null;
       }
-      return parsed.projects;
+      return { projects: parsed.projects, scannedAt: parsed.createdAt };
     } catch {
       return null;
     }
   }
 
-  set(key: string, projects: Project[]): void {
+  set(key: string, projects: Project[], validationPaths: string[], scannedAt: string): void {
     mkdirSync(this.cacheDir, { recursive: true });
     const record: ScanCacheRecord = {
       version: SCAN_CACHE_VERSION,
-      createdAt: new Date().toISOString(),
+      createdAt: scannedAt,
       projects,
+      validationEntries: this.captureValidationEntries(validationPaths),
     };
     writeFileSync(this.getEntryPath(key), `${JSON.stringify(record)}\n`, 'utf8');
   }
@@ -76,5 +88,33 @@ export class FileScanCacheStore implements ScanCacheStore {
 
   private getEntryPath(key: string): string {
     return path.join(this.cacheDir, `${key}.json`);
+  }
+
+  private captureValidationEntries(validationPaths: string[]): ValidationEntry[] {
+    const entries: ValidationEntry[] = [];
+    for (const trackedPath of [...new Set(validationPaths)]) {
+      entries.push({
+        path: trackedPath,
+        mtimeMs: this.tryGetMtimeMs(trackedPath),
+      });
+    }
+    return entries;
+  }
+
+  private isValidationSnapshotCurrent(validationEntries: ValidationEntry[]): boolean {
+    for (const entry of validationEntries) {
+      if (this.tryGetMtimeMs(entry.path) !== entry.mtimeMs) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private tryGetMtimeMs(targetPath: string): number | null {
+    try {
+      return statSync(targetPath).mtimeMs;
+    } catch {
+      return null;
+    }
   }
 }

--- a/tests/infrastructure/scan-cache.test.ts
+++ b/tests/infrastructure/scan-cache.test.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FileScanCacheStore } from '../../packages/platform-node/src/scan-cache.js';
+
+const SCANNED_AT = '2026-03-21T12:00:00.000Z';
+
+describe('FileScanCacheStore', () => {
+  it('reuses cache entries while tracked paths stay unchanged', () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'gfos-build-scan-cache-'));
+    try {
+      const cacheDir = path.join(tempDir, 'cache');
+      const trackedDir = path.join(tempDir, 'workspace');
+      const trackedFile = path.join(trackedDir, 'pom.xml');
+
+      mkdirSync(trackedDir, { recursive: true });
+      writeFileSync(trackedFile, '<project />', 'utf8');
+
+      const store = new FileScanCacheStore(cacheDir);
+      const projects = [{ name: 'demo', path: trackedDir, depth: 0, rootName: 'ws', buildSystem: 'maven' }] as const;
+
+      store.set('scan-key', [...projects], [trackedDir, trackedFile], SCANNED_AT);
+
+      expect(store.get('scan-key', 60_000)).toEqual({
+        projects: [...projects],
+        scannedAt: SCANNED_AT,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates cache entries when a tracked file changes', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'gfos-build-scan-cache-'));
+    try {
+      const cacheDir = path.join(tempDir, 'cache');
+      const trackedDir = path.join(tempDir, 'workspace');
+      const trackedFile = path.join(trackedDir, 'pom.xml');
+
+      mkdirSync(trackedDir, { recursive: true });
+      writeFileSync(trackedFile, '<project />', 'utf8');
+
+      const store = new FileScanCacheStore(cacheDir);
+      const projects = [{ name: 'demo', path: trackedDir, depth: 0, rootName: 'ws', buildSystem: 'maven' }] as const;
+
+      store.set('scan-key', [...projects], [trackedDir, trackedFile], SCANNED_AT);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      writeFileSync(trackedFile, '<project><artifactId>demo</artifactId></project>', 'utf8');
+
+      expect(store.get('scan-key', 60_000)).toBeNull();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('invalidates cache entries when a tracked directory changes', async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), 'gfos-build-scan-cache-'));
+    try {
+      const cacheDir = path.join(tempDir, 'cache');
+      const trackedDir = path.join(tempDir, 'workspace');
+      const trackedFile = path.join(trackedDir, 'package.json');
+
+      mkdirSync(trackedDir, { recursive: true });
+      writeFileSync(trackedFile, '{"name":"demo"}', 'utf8');
+
+      const store = new FileScanCacheStore(cacheDir);
+      const projects = [{ name: 'demo', path: trackedDir, depth: 0, rootName: 'ws', buildSystem: 'node' }] as const;
+
+      store.set('scan-key', [...projects], [trackedDir, trackedFile], SCANNED_AT);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      mkdirSync(path.join(trackedDir, 'packages'));
+
+      expect(store.get('scan-key', 60_000)).toBeNull();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What Changed

- improved project scan cache reuse by validating tracked filesystem paths instead of relying on frequent full rescans
- kept the Projects page stable during refreshes by merging updated scan results into query state instead of hard reloading the view
- added automatic background validation for older cached scans and regression coverage for cache invalidation behavior

## Why

The project scan was too eager to fall back to full reloads, which made the feature feel slower than necessary during normal developer usage. This change keeps scan results responsive while still invalidating correctly when project roots or tracked manifests change.

## UI Changes

- No visual layout changes.
- Interaction change: the Projects page keeps search/filter/expansion state stable while background scan refreshes apply in place.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Closes #53
